### PR TITLE
Fix the HTML em dash entity

### DIFF
--- a/regdown/__init__.py
+++ b/regdown/__init__.py
@@ -123,9 +123,9 @@ class RegulationsExtension(Extension):
 
 
 class EmDashPattern(Pattern):
-    """ Replace '---' with an &emdash; """
+    """ Replace '---' with an &mdash; """
     def handleMatch(self, m):
-        return '{}emdash;'.format(util.AMP_SUBSTITUTE)
+        return '{}mdash;'.format(util.AMP_SUBSTITUTE)
 
 
 class PseudoFormPattern(Pattern):

--- a/regdown/tests.py
+++ b/regdown/tests.py
@@ -300,7 +300,7 @@ class RegulationsExtensionTestCase(unittest.TestCase):
         self.assertIn('§&#160;1023.4(a)', regdown('§&#160;1023.4(a)'))
 
     def test_emdash(self):
-        self.assertIn('Some &emdash; text', regdown('Some --- text'))
+        self.assertIn('Some &mdash; text', regdown('Some --- text'))
 
 
 class RegdownUtilsTestCase(unittest.TestCase):


### PR DESCRIPTION
My attempt to bring em-dash support directly into Regdown is impeded by using the wrong HTML entity. This PR fixes that.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
