### PR TITLE
Update for Markdown 3.2, drop 3.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,10 @@ matrix:
   include:
     - env: TOXENV=lint
       python: 3.6
-    - env: TOXENV=py27-md30
-      python: 2.7
-    - env: TOXENV=py27-md31
-      python: 2.7
-    - env: TOXENV=py36-md30
+    - env: TOXENV=py36-md32
       python: 3.6
-    - env: TOXENV=py36-md31
-      python: 3.6
-    - env: TOXENV=py37-md30
-      python: 3.7
-    - env: TOXENV=py37-md31
-      python: 3.7
+    - env: TOXENV=py38-md32
+      python: 3.8
 
 install:
   pip install tox coveralls

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Regdown is a [Python-Markdown](https://python-markdown.github.io) extension for 
 
 ## Dependencies
 
-- Python 2.7+, 3.6+
-- [Python-Markdown](https://python-markdown.github.io) 3.0+
+- Python 3.6, 3.8
+- [Python-Markdown](https://python-markdown.github.io) 3.2
 
 ## Installation
 

--- a/regdown/__init__.py
+++ b/regdown/__init__.py
@@ -6,11 +6,7 @@ import re
 from markdown import markdown, util
 from markdown.blockprocessors import BlockProcessor, ParagraphProcessor
 from markdown.extensions import Extension
-from markdown.inlinepatterns import (
-    DoubleTagInlineProcessor,
-    Pattern,
-    SimpleTagInlineProcessor,
-)
+from markdown.inlinepatterns import DoubleTagInlineProcessor, Pattern
 
 
 # If we're on Python 3.6+ we have SHA3 built-in, otherwise use the back-ported

--- a/regdown/__init__.py
+++ b/regdown/__init__.py
@@ -73,7 +73,6 @@ class RegulationsExtension(Extension):
 
         # Replace all inlinePatterns that include an underscore with patterns
         # that do not include underscores.
-        md.inlinePatterns.deregister('strong_em')
         md.inlinePatterns.deregister('em_strong')
         md.inlinePatterns.deregister('strong')
         md.inlinePatterns.deregister('strong2')
@@ -83,11 +82,6 @@ class RegulationsExtension(Extension):
             DoubleTagInlineProcessor(EM_STRONG_RE, 'strong,em'),
             'em_strong',
             60
-        )
-        md.inlinePatterns.register(
-            DoubleTagInlineProcessor(STRONG_EM_RE, 'em,strong'),
-            'strong_em',
-            50
         )
         md.inlinePatterns.register(
             SimpleTagInlineProcessor(STRONG_RE, 'strong'), 'strong', 40)

--- a/regdown/__init__.py
+++ b/regdown/__init__.py
@@ -21,14 +21,8 @@ except ImportError:  # pragma: no cover
     from sha3 import sha3_224
 
 
-# **strong**
-STRONG_RE = r'(\*{2})(.+?)\1'
-
 # ***strongem*** or ***em*strong**
 EM_STRONG_RE = r'(\*)\1{2}(.+?)\1(.*?)\1{2}'
-
-# ***strong**em*
-STRONG_EM_RE = r'(\*)\1{2}(.+?)\1{2}(.*?)\1'
 
 # Form field: __
 # __Form Field
@@ -74,7 +68,6 @@ class RegulationsExtension(Extension):
         # Replace all inlinePatterns that include an underscore with patterns
         # that do not include underscores.
         md.inlinePatterns.deregister('em_strong')
-        md.inlinePatterns.deregister('strong')
         md.inlinePatterns.deregister('strong2')
         md.inlinePatterns.deregister('emphasis2')
 
@@ -83,8 +76,6 @@ class RegulationsExtension(Extension):
             'em_strong',
             60
         )
-        md.inlinePatterns.register(
-            SimpleTagInlineProcessor(STRONG_RE, 'strong'), 'strong', 40)
 
         # Add inline emdash and pseudo form patterns.
         md.inlinePatterns.register(EmDashPattern(EMDASH_RE), 'emdash', 200)

--- a/regdown/__init__.py
+++ b/regdown/__init__.py
@@ -67,7 +67,7 @@ class RegulationsExtension(Extension):
 
         # Replace all inlinePatterns that include an underscore with patterns
         # that do not include underscores.
-        md.inlinePatterns.deregister('em_strong')
+        md.inlinePatterns.deregister('em_strong2')
 
         md.inlinePatterns.register(
             DoubleTagInlineProcessor(EM_STRONG_RE, 'strong,em'),

--- a/regdown/__init__.py
+++ b/regdown/__init__.py
@@ -68,7 +68,6 @@ class RegulationsExtension(Extension):
         # Replace all inlinePatterns that include an underscore with patterns
         # that do not include underscores.
         md.inlinePatterns.deregister('em_strong')
-        md.inlinePatterns.deregister('emphasis2')
 
         md.inlinePatterns.register(
             DoubleTagInlineProcessor(EM_STRONG_RE, 'strong,em'),

--- a/regdown/__init__.py
+++ b/regdown/__init__.py
@@ -68,7 +68,6 @@ class RegulationsExtension(Extension):
         # Replace all inlinePatterns that include an underscore with patterns
         # that do not include underscores.
         md.inlinePatterns.deregister('em_strong')
-        md.inlinePatterns.deregister('strong2')
         md.inlinePatterns.deregister('emphasis2')
 
         md.inlinePatterns.register(

--- a/regdown/__init__.py
+++ b/regdown/__init__.py
@@ -67,7 +67,7 @@ class RegulationsExtension(Extension):
 
         md.inlinePatterns.register(
             DoubleTagInlineProcessor(EM_STRONG_RE, 'strong,em'),
-            'em_strong',
+            'em_strong2',
             60
         )
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
 
 
 install_requires = [
-    'Markdown>=3.0,<3.2',
+    'Markdown>=3.0,<4.0',
     'sha3==0.2.1',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,6 @@ setup(
         'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
         'License :: Public Domain',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
 
 
 install_requires = [
-    'Markdown>=3.0,<4.0',
+    'Markdown>=3.2',
     'sha3==0.2.1',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
 
 
 install_requires = [
-    'Markdown>=3.0,<4.0',
+    'Markdown>=3.0,<3.2',
     'sha3==0.2.1',
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist=True
 envlist=
     lint,
-    py{27,36,37}-md{30,31}
+    py{36,38}-md{32}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -12,13 +12,11 @@ commands=
     coverage report -m
 
 basepython=
-    py27: python2.7
     py36: python3.6
-    py37: python3.7
+    py38: python3.8
 
 deps=
-    md30: Markdown>=3.0,<3.1
-    md31: Markdown>=3.1,<3.2
+    md32: Markdown>=3.2,<3.3
 
 [testenv:lint]
 basepython=python3.6
@@ -42,7 +40,7 @@ include_trailing_comma=1
 multi_line_output=3
 skip=.tox
 use_parentheses=1
-known_future_library=future,six
+known_future_library=future
 default_section=THIRDPARTY
 sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 


### PR DESCRIPTION
Fix ValueError: No item named "strong_em" exists raised in wagtail-regulations

## Removals

Removed the following from `regdown/__init__.py`
- STRONG_EM_RE
- emphasis2
- strong_em
- strong2
- strong

## Changes

- `em_strong` replaced by `em_strong2`

## Testing

1. tox

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: