### PR TITLE
Remove unnecessary dependency on sha3 package

### DIFF
--- a/regdown/__init__.py
+++ b/regdown/__init__.py
@@ -1,18 +1,11 @@
 # -*- coding: utf-8 -*-
 import re
+from hashlib import sha3_224
 
 from markdown import markdown, util
 from markdown.blockprocessors import BlockProcessor, ParagraphProcessor
 from markdown.extensions import Extension
 from markdown.inlinepatterns import DoubleTagInlineProcessor, Pattern
-
-
-# If we're on Python 3.6+ we have SHA3 built-in, otherwise use the back-ported
-# sha3 library.
-try:
-    from hashlib import sha3_224
-except ImportError:  # pragma: no cover
-    from sha3 import sha3_224
 
 
 # ***strongem*** or ***em*strong**

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ with open("README.md") as f:
 
 install_requires = [
     "Markdown>=3.2",
-    "sha3==0.2.1",
 ]
 
 


### PR DESCRIPTION
The README states that this project requires Python 3.6+, which means that SHA3 is [always available as part of hashlib](https://docs.python.org/3.6/library/hashlib.html#hash-algorithms).

This means that we no longer need to install an additional [sha3](https://pypi.org/project/sha3/) package. Installing this package on Python 3.6 can cause issues with pip because it [overrides the _sha3 module](https://github.com/bjornedstrom/python-sha3/blob/0196c7777e676d72b43bfc0f749f3e20d3105f41/setup.py#L5) in unexpected ways.