### PR TITLE
Include `attr_list` extension, allowing regdown users to set html attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4
+
+- Include attr_list, allowing regdown users to set html attributes
+
 ## 1.0.3
 
 - Replace Travis with GitHub Actions and Replace Travis Badge with Github Action Badge

--- a/regdown/__init__.py
+++ b/regdown/__init__.py
@@ -259,6 +259,7 @@ def regdown(text, **kwargs):
         text,
         extensions=[
             "markdown.extensions.tables",
+            "attr_list",
             RegulationsExtension(**kwargs),
         ],
         **kwargs,

--- a/regdown/__init__.py
+++ b/regdown/__init__.py
@@ -98,7 +98,7 @@ class RegulationsExtension(Extension):
 
 
 class EmDashPattern(Pattern):
-    """ Replace '---' with an &mdash; """
+    """Replace '---' with an &mdash;"""
 
     def handleMatch(self, m):
         return "{}mdash;".format(util.AMP_SUBSTITUTE)
@@ -119,7 +119,7 @@ class PseudoFormPattern(Pattern):
 
 
 class SectionSymbolPattern(Pattern):
-    """ Make whitespace after a section symbol non-breaking """
+    """Make whitespace after a section symbol non-breaking"""
 
     def handleMatch(self, m):
         return "{section}{stx}{char}{etx}#160;".format(

--- a/regdown/tests.py
+++ b/regdown/tests.py
@@ -195,7 +195,7 @@ class RegulationsExtensionTestCase(unittest.TestCase):
         )
 
     def test_makeExtension(self):
-        """ Test that Markdown can load our extension from a string """
+        """Test that Markdown can load our extension from a string"""
         try:
             markdown.Markdown(extensions=["regdown"])
         except AttributeError as e:  # pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license="CC0",
-    version="1.0.3",
+    version="1.0.4",
     include_package_data=True,
     packages=find_packages(),
     test_suite="regdown.tests",

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps=
     md32: Markdown>=3.2,<3.3
 
 [testenv:lint]
-basepython=python3.6
+basepython=python3.8
 deps=
     black
     flake8


### PR DESCRIPTION
While this extension seems generally useful, the specific use-case of `attr_list` will be allowing`loading="lazy"` on `img` tags (which is a huge win for some reg appendix pages with >100 below-the-fold PNGs).