### PR TITLE
Publish to PyPI on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,39 +1,32 @@
-name: Publish
-
+name: Publish to PyPI
 on:
   release:
     types: [published]
+
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: "3.10"
 
-      - name: Install Python dependencies
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install wheel
+          pip install twine wheel
 
-      - name: Build the packages
+      - name: Build the package
         id: build
         run: |
-          python setup.py bdist_wheel
-          # Get the name of the .whl file and set them as
-          # "outputs" of this step so we can upload them
-          echo "::set-output name=bdist_wheel::$(cd dist && ls *.whl)"
+          python setup.py sdist bdist_wheel --universal
 
-      - name: Upload the wheel
-        uses: actions/upload-release-asset@v1
+      - name: Upload to PyPI
+        run: twine upload dist/*
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: dist/${{ steps.build.outputs.bdist_wheel }}
-          asset_name: ${{ steps.build.outputs.bdist_wheel }}
-          asset_content_type: application/zip
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}


### PR DESCRIPTION
This change updates our release workflow to publish to PyPI on release rather than attaching the built package to the GitHub release. This is consistent with our other, newer Python packages, like [Django-Flags](https://github.com/cfpb/django-flags/blob/main/.github/workflows/release.yml), [wagtail-sharing](https://github.com/cfpb/wagtail-sharing/blob/main/.github/workflows/release.yml), etc.

The `TWINE_USERNAME` and `TWINE_PASSWORD` secrets already exist on this repo.