### PR TITLE
Replace the use of deprecated `markdown.util.etree`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |
@@ -32,26 +32,29 @@ jobs:
     strategy:
       matrix:
         toxenv:
-            - py36-md32
             - py38-md32
+            - py38-mdlatest
+            - py310-mdlatest
         include:
-          - toxenv: py36-md32
-            python-version: 3.6
           - toxenv: py38-md32
-            python-version: 3.8
+            python-version: "3.8"
+          - toxenv: py38-mdlatest
+            python-version: "3.8"
+          - toxenv: py310-mdlatest
+            python-version: "3.10"
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox coveralls
+          pip install tox
 
       - name: Run tox
         run: |
@@ -59,9 +62,37 @@ jobs:
         env:
           TOXENV: ${{ matrix.toxenv }}
 
-      - name: Run coveralls
+      - name: Store test coverage
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage
+          path: .coverage.*
+
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    needs:
+      - test
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
         run: |
-          coveralls
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          python -m pip install --upgrade pip
+          pip install tox
+
+      - name: Retrieve test coverage
+        uses: actions/download-artifact@v2
+        with:
+          name: coverage
+
+      - name: Check coverage
+        run: tox -e coverage

--- a/regdown/__init__.py
+++ b/regdown/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import re
 from hashlib import sha3_224
+from xml.etree import ElementTree as ET
 
 from markdown import markdown, util
 from markdown.blockprocessors import BlockProcessor, ParagraphProcessor
@@ -109,11 +110,11 @@ class PseudoFormPattern(Pattern):
     given pseudo-form pattern."""
 
     def handleMatch(self, m):
-        el = util.etree.Element("span")
+        el = ET.Element("span")
         el.set("class", "regdown-form")
         if m.group("line_ending") is not None:
             el.set("class", "regdown-form_extend")
-            util.etree.SubElement(el, "span")
+            ET.SubElement(el, "span")
         el.text = m.group("underscores")
         return el
 
@@ -152,9 +153,9 @@ class LabeledParagraphProcessor(ParagraphProcessor):
             label, text = match.group("label"), match.group("text")
             # Labeled paragraphs without text should use a div element
             if text == "":
-                el = util.etree.SubElement(parent, "div")
+                el = ET.SubElement(parent, "div")
             else:
-                el = util.etree.SubElement(parent, "p")
+                el = ET.SubElement(parent, "p")
             el.set("id", label)
             el.set("data-label", label)
 
@@ -190,7 +191,7 @@ class LabeledParagraphProcessor(ParagraphProcessor):
                 text = block.lstrip()
                 label = sha3_224(text.encode("utf-8")).hexdigest()
                 class_name = "regdown-block"
-                p = util.etree.SubElement(parent, "p")
+                p = ET.SubElement(parent, "p")
                 p.set("id", label)
                 p.set("class", class_name)
                 p.set("data-label", "")
@@ -242,9 +243,7 @@ class BlockReferenceProcessor(BlockProcessor):
 
             rendered_contents = self.render_block_reference(contents, url=url)
 
-            parent.append(
-                util.etree.fromstring(rendered_contents.encode("utf-8"))
-            )
+            parent.append(ET.fromstring(rendered_contents.encode("utf-8")))
 
 
 def makeExtension(*args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 
 install_requires = [
-    "Markdown>=3.2",
+    "Markdown>=3.2,<3.5",
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,24 +2,24 @@
 skipsdist=True
 envlist=
     lint,
-    py{36,38}-md{32}
+    py{38,310}-md{32,latest},
+    coverage
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
 commands=
-    coverage erase
-    coverage run --source='regdown' setup.py test {posargs}
-    coverage report -m
+    python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m coverage run --parallel-mode --source='regdown' setup.py test {posargs}
 
 basepython=
-    py36: python3.6
-    py38: python3.8
+    py38:  python3.8
+    py310: python3.10
 
 deps=
-    md32: Markdown>=3.2,<3.3
+    md32:       Markdown>=3.2,<3.3
+    mdlatest:   Markdown>=3.2
 
 [testenv:lint]
-basepython=python3.8
+basepython=python3.10
 deps=
     black
     flake8
@@ -28,6 +28,16 @@ commands=
     black --check regdown setup.py
     flake8 regdown
     isort --check-only --diff regdown
+
+[testenv:coverage]
+basepython=python3.10
+deps=
+    coverage
+    diff_cover
+commands=
+    coverage combine
+    coverage xml
+    diff-cover coverage.xml --compare-branch=origin/main --fail-under=100
 
 [flake8]
 ignore=E731,W503,W504


### PR DESCRIPTION
This change replaces the use of the deprecated `markdown.util.etree` with the builtin `xml.etree.ElementTree`.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
