### PR TITLE
Prep for 1.0.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.5
+
+- Replace the use of deprecated markdown.util.etree
+- Changed Python 3.7 to 3.10
+- Pin markdown under 3.5
+
 ## 1.0.4
 
 - Include attr_list, allowing regdown users to set html attributes

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license="CC0",
-    version="1.0.4",
+    version="1.0.5",
     include_package_data=True,
     packages=find_packages(),
     test_suite="regdown.tests",


### PR DESCRIPTION
Updates the changelog and version number, so that we can release the changes from https://github.com/cfpb/regdown/pull/7