### PR TITLE
Add Python 3.13 support, drop support for 3.8, 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: ci
 
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
 
@@ -8,12 +8,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |
@@ -31,15 +31,15 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.8", "3.11"]
+        python: ["3.10", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python }}
 
       - name: Install dependencies
         run: |
@@ -53,10 +53,11 @@ jobs:
           TOXENV: python${{ matrix.python }}
 
       - name: Store test coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-${{ matrix.python }}
           path: .coverage.*
+          include-hidden-files: true
 
   coverage:
     name: coverage
@@ -65,14 +66,14 @@ jobs:
       - test
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |
@@ -80,9 +81,9 @@ jobs:
           pip install tox
 
       - name: Retrieve test coverage
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
-          name: coverage
+          merge-multiple: true
 
       - name: Check coverage
         run: tox -e coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.0.7"
 description = "Markdown extension for interactive regulations"
 readme = "README.md"
 requires-python = ">=3.10"
-license-files = ["LICENSE", "TERMS.md"]
+license = "CC0-1.0"
 authors = [
     {name = "CFPB", email = "tech@cfpb.gov" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ name = "regdown"
 version = "1.0.7"
 description = "Markdown extension for interactive regulations"
 readme = "README.md"
-requires-python = ">=3.8"
-license = {text = "CC0"}
+requires-python = ">=3.10"
+license-files = ["LICENSE", "TERMS.md"]
 authors = [
     {name = "CFPB", email = "tech@cfpb.gov" }
 ]
@@ -12,8 +12,6 @@ dependencies = [
     "Markdown>=3.4",
 ]
 classifiers = [
-    "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
-    "License :: Public Domain",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
 ]
@@ -24,49 +22,45 @@ classifiers = [
 "Source" = "https://github.com/cfpb/regdown"
 
 [build-system]
-requires = ["setuptools>=43.0.0", "wheel"]
+requires = ["setuptools>=63", "setuptools_scm[toml]>=8"]
 build-backend = "setuptools.build_meta"
 
-[tool.black]
-line-length = 79
-target-version = ["py38"]
-include = '\.pyi?$'
-exclude = '''
-(
-  /(
-      \.eggs
-    | \.git
-    | \.tox
-    | \*.egg-info
-    | _build
-    | build
-    | dist
-    | migrations
-    | site
-  )/
-)
-'''
-
-[tool.isort]
-profile = "black"
-line_length = 79
-lines_after_imports = 2
-skip = [".tox", ".venv", "venv"]
-
 [tool.ruff]
+# Use PEP8 line-length
+line-length = 79
+# Exclude common paths
 exclude = [
     ".git",
     ".tox",
     "__pycache__",
 ]
+
+[tool.ruff.lint]
+ignore = []
+# Select specific rulesets to use
 select = [
+    # pycodestyle
     "E",
+    # pyflakes
     "F",
-    "W",
+    # flake8-bugbear
+    "B",
+    # pyupgrade
+    "UP",
+    # flake8-simplify
+    "SIM",
+    # isort
+    "I",
 ]
-ignore = [
-    # Assigned Lambdas are fine.
-    "E731",
+
+[tool.ruff.lint.isort]
+lines-after-imports = 2
+section-order = [
+    "future",
+    "standard-library",
+    "third-party",
+    "first-party",
+    "local-folder",
 ]
 
 [tool.coverage.run]

--- a/tox.ini
+++ b/tox.ini
@@ -2,33 +2,32 @@
 skipsdist=True
 envlist=
     lint,
-    python{3.8,3.11},
+    python{3.10,3.12,3.13},
     coverage
 
 [testenv]
+install_command=pip install -e "." -U {opts} {packages}
 deps=
     coverage[toml]
 
 commands=
-    python -W error::DeprecationWarning -W error::PendingDeprecationWarning -b -m coverage run --parallel-mode --source='regdown' setup.py test {posargs}
+    python -W error::DeprecationWarning -W error::PendingDeprecationWarning -b -m coverage run --parallel-mode --source=regdown -m unittest
 
 basepython=
-    python3.8: python3.8
-    python3.11: python3.11
+    python3.10: python3.10
+    python3.12: python3.12
+    python3.13: python3.13
 
 [testenv:lint]
-basepython=python3.11
+basepython=python3.13
 deps=
-    black
     ruff
-    isort
 commands=
-    black --check regdown setup.py
-    ruff regdown
-    isort --check-only --diff regdown
+    ruff format --check
+    ruff check regdown
 
 [testenv:coverage]
-basepython=python3.11
+basepython=python3.13
 deps=
     coverage
     diff_cover


### PR DESCRIPTION
Python 3.8 reached EOL on 10/7/24.
Python 3.9 reached EOL on 10/31/25.

Also modernize some aspects of the pyproject.toml file and how linting and testing are done.